### PR TITLE
removed references to deleted file CaptureOnly.cs

### DIFF
--- a/SampleCode.cs
+++ b/SampleCode.cs
@@ -66,7 +66,6 @@ namespace net.authorize.sample
         {
             
             Console.WriteLine("    ChargeCreditCard");
-            Console.WriteLine("    CaptureOnly");
             Console.WriteLine("    AuthorizeCreditCard");
             Console.WriteLine("    CapturePreviouslyAuthorizedAmount");
             Console.WriteLine("    CaptureFundsAuthorizedThroughAnotherChannel");
@@ -193,9 +192,6 @@ namespace net.authorize.sample
                     break;
                 case "ChargeCreditCard":
                     ChargeCreditCard.Run(apiLoginId, transactionKey);
-                    break;
-                case "CaptureOnly":
-                    CaptureOnly.Run(apiLoginId, transactionKey);
                     break;
                 case "CapturePreviouslyAuthorizedAmount":
                     Console.WriteLine("Enter An Transaction Amount");

--- a/SampleCode.csproj
+++ b/SampleCode.csproj
@@ -64,7 +64,6 @@
     <Compile Include="HostedPaymentForm\CreateHostedPaymentTransaction.cs" />
     <Compile Include="PaymentTransactions\AuthorizeCreditCard.cs" />
     <Compile Include="PaymentTransactions\CaptureFundsAuthorizedThroughAnotherChannel.cs" />
-    <Compile Include="PaymentTransactions\CaptureOnly.cs" />
     <Compile Include="PaymentTransactions\CapturePreviouslyAuthorizedAmount.cs" />
     <Compile Include="PaymentTransactions\ChargeCreditCard.cs" />
     <Compile Include="PaymentTransactions\ChargeCustomerProfile.cs" />


### PR DESCRIPTION
Following discussion on https://github.com/AuthorizeNet/sample-code-csharp/issues/28, CaptureOnly.cs was deleted. I have therefore deleted the lines of code where this file was referenced, so that the user doesn't accidentally try to access it (and break the code).
