### PR TITLE
Remove duplicate AuthorizeNet package reference

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AuthorizeNet" version="1.8.8" targetFramework="net45" />
-  <package id="AuthorizeNet" version="1.8.8" targetFramework="net40" />
+  <package id="AuthorizeNet" version="1.8.8" />
 </packages>


### PR DESCRIPTION
Having duplicate references was causing a problem in VS2015 that prevented automatic package restore, resulting in missing reference build errors. Removing the additional reference, as well as the `targetFramework` attribute seems to resolve the issue.

Should fix #36
