### PR TITLE
Sample code change for Routing/Account Number

### DIFF
--- a/CustomerProfiles/CreateCustomerProfile.cs
+++ b/CustomerProfiles/CreateCustomerProfile.cs
@@ -26,7 +26,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0719"
+                expirationDate  = "0728"
             };
 
             var bankAccount = new bankAccountType

--- a/CustomerProfiles/CreateCustomerProfile.cs
+++ b/CustomerProfiles/CreateCustomerProfile.cs
@@ -26,7 +26,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0718"
+                expirationDate  = "0719"
             };
 
             var bankAccount = new bankAccountType

--- a/CustomerProfiles/UpdateCustomerPaymentProfile.cs
+++ b/CustomerProfiles/UpdateCustomerPaymentProfile.cs
@@ -27,7 +27,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0719"
+                expirationDate = "0728"
             };
 
             //===========================================================================

--- a/CustomerProfiles/UpdateCustomerPaymentProfile.cs
+++ b/CustomerProfiles/UpdateCustomerPaymentProfile.cs
@@ -27,7 +27,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0718"
+                expirationDate = "0719"
             };
 
             //===========================================================================

--- a/CustomerProfiles/UpdateCustomerShippingAddress.cs
+++ b/CustomerProfiles/UpdateCustomerShippingAddress.cs
@@ -27,7 +27,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
              {
                  cardNumber = "4111111111111111",
-                 expirationDate = "0719"
+                 expirationDate = "0728"
              };
 
             var paymentType = new paymentType { Item = creditCard };

--- a/CustomerProfiles/UpdateCustomerShippingAddress.cs
+++ b/CustomerProfiles/UpdateCustomerShippingAddress.cs
@@ -27,7 +27,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
              {
                  cardNumber = "4111111111111111",
-                 expirationDate = "0718"
+                 expirationDate = "0719"
              };
 
             var paymentType = new paymentType { Item = creditCard };

--- a/PaymentTransactions/AuthorizeCreditCard.cs
+++ b/PaymentTransactions/AuthorizeCreditCard.cs
@@ -27,7 +27,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0718"
+                expirationDate  = "0719"
             };
 
             //standard api call to retrieve response

--- a/PaymentTransactions/AuthorizeCreditCard.cs
+++ b/PaymentTransactions/AuthorizeCreditCard.cs
@@ -27,7 +27,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0719"
+                expirationDate  = "0728"
             };
 
             //standard api call to retrieve response

--- a/PaymentTransactions/CaptureFundsAuthorizedThroughAnotherChannel.cs
+++ b/PaymentTransactions/CaptureFundsAuthorizedThroughAnotherChannel.cs
@@ -29,7 +29,7 @@ namespace net.authorize.sample
             {
                 // Change the cardNumber and expiration Date as required
                 cardNumber = "4111111111111111",
-                expirationDate = "0719"
+                expirationDate = "0728"
             };
 
             //standard api call to retrieve response

--- a/PaymentTransactions/CaptureFundsAuthorizedThroughAnotherChannel.cs
+++ b/PaymentTransactions/CaptureFundsAuthorizedThroughAnotherChannel.cs
@@ -29,7 +29,7 @@ namespace net.authorize.sample
             {
                 // Change the cardNumber and expiration Date as required
                 cardNumber = "4111111111111111",
-                expirationDate = "0718"
+                expirationDate = "0719"
             };
 
             //standard api call to retrieve response

--- a/PaymentTransactions/ChargeCreditCard.cs
+++ b/PaymentTransactions/ChargeCreditCard.cs
@@ -28,7 +28,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0718",
+                expirationDate = "0719",
                 cardCode = "123"
             };
 

--- a/PaymentTransactions/ChargeCreditCard.cs
+++ b/PaymentTransactions/ChargeCreditCard.cs
@@ -28,7 +28,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0719",
+                expirationDate = "0728",
                 cardCode = "123"
             };
 

--- a/PaymentTransactions/ChargeTokenizedCreditCard.cs
+++ b/PaymentTransactions/ChargeTokenizedCreditCard.cs
@@ -28,7 +28,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0718",
+                expirationDate = "0719",
                 // Set the token specific info
                 isPaymentToken = true,
                 cryptogram = "EjRWeJASNFZ4kBI0VniQEjRWeJA="             // Set this to the value of the cryptogram received from the token provide

--- a/PaymentTransactions/ChargeTokenizedCreditCard.cs
+++ b/PaymentTransactions/ChargeTokenizedCreditCard.cs
@@ -28,7 +28,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0719",
+                expirationDate = "0728",
                 // Set the token specific info
                 isPaymentToken = true,
                 cryptogram = "EjRWeJASNFZ4kBI0VniQEjRWeJA="             // Set this to the value of the cryptogram received from the token provide

--- a/PaymentTransactions/DebitBankAccount.cs
+++ b/PaymentTransactions/DebitBankAccount.cs
@@ -24,7 +24,7 @@ namespace net.authorize.sample
                 Item = ApiTransactionKey
             };
 
-            Random rand = new Random();
+            Random rand = new Random(); 
             int randomAccountNumber = rand.Next(100000000, int.MaxValue);
 
             var bankAccount = new bankAccountType

--- a/PaymentTransactions/DebitBankAccount.cs
+++ b/PaymentTransactions/DebitBankAccount.cs
@@ -30,8 +30,8 @@ namespace net.authorize.sample
             var bankAccount = new bankAccountType
             {
                 accountType     = bankAccountTypeEnum.savings,
-                routingNumber   = "121141754",//"125008547",
-                accountNumber   = randomAccountNumber.ToString(), //"1234567890",
+                routingNumber   = "125008547",
+                accountNumber   = randomAccountNumber.ToString(),
                 nameOnAccount   = "John Doe",
                 echeckType      = echeckTypeEnum.WEB,   // change based on how you take the payment (web, telephone, etc)
                 bankName        = "Wells Fargo Bank NA",

--- a/PaymentTransactions/DebitBankAccount.cs
+++ b/PaymentTransactions/DebitBankAccount.cs
@@ -25,7 +25,7 @@ namespace net.authorize.sample
             };
 
             Random rand = new Random(); 
-            int randomAccountNumber = rand.Next(100000000, int.MaxValue);
+            int randomAccountNumber = rand.Next(10000, int.MaxValue);
 
             var bankAccount = new bankAccountType
             {

--- a/PaymentTransactions/DebitBankAccount.cs
+++ b/PaymentTransactions/DebitBankAccount.cs
@@ -29,7 +29,7 @@ namespace net.authorize.sample
 
             var bankAccount = new bankAccountType
             {
-                accountType     = bankAccountTypeEnum.savings,
+                accountType     = bankAccountTypeEnum.checking,
                 routingNumber   = "125008547",
                 accountNumber   = randomAccountNumber.ToString(), 
                 nameOnAccount   = "John Doe",

--- a/PaymentTransactions/DebitBankAccount.cs
+++ b/PaymentTransactions/DebitBankAccount.cs
@@ -31,7 +31,7 @@ namespace net.authorize.sample
             {
                 accountType     = bankAccountTypeEnum.savings,
                 routingNumber   = "125008547",
-                accountNumber   = randomAccountNumber.ToString(),
+                accountNumber   = randomAccountNumber.ToString(), 
                 nameOnAccount   = "John Doe",
                 echeckType      = echeckTypeEnum.WEB,   // change based on how you take the payment (web, telephone, etc)
                 bankName        = "Wells Fargo Bank NA",

--- a/PaymentTransactions/DebitBankAccount.cs
+++ b/PaymentTransactions/DebitBankAccount.cs
@@ -24,11 +24,14 @@ namespace net.authorize.sample
                 Item = ApiTransactionKey
             };
 
+            Random rand = new Random();
+            int randomAccountNumber = rand.Next(100000000, int.MaxValue);
+
             var bankAccount = new bankAccountType
             {
-                accountType     = bankAccountTypeEnum.checking,
-                routingNumber   = "125008547",
-                accountNumber   = "1234567890",
+                accountType     = bankAccountTypeEnum.savings,
+                routingNumber   = "121141754",//"125008547",
+                accountNumber   = randomAccountNumber.ToString(), //"1234567890",
                 nameOnAccount   = "John Doe",
                 echeckType      = echeckTypeEnum.WEB,   // change based on how you take the payment (web, telephone, etc)
                 bankName        = "Wells Fargo Bank NA",

--- a/RecurringBilling/CreateSubscription.cs
+++ b/RecurringBilling/CreateSubscription.cs
@@ -40,7 +40,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0718"
+                expirationDate  = "0719"
             };
 
             //standard api call to retrieve response

--- a/RecurringBilling/CreateSubscription.cs
+++ b/RecurringBilling/CreateSubscription.cs
@@ -40,7 +40,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0719"
+                expirationDate  = "0728"
             };
 
             //standard api call to retrieve response

--- a/RecurringBilling/CreateSubscriptionFromCustomerProfile.cs
+++ b/RecurringBilling/CreateSubscriptionFromCustomerProfile.cs
@@ -41,7 +41,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0719"
+                expirationDate  = "0728"
             };
 
             //standard api call to retrieve response

--- a/RecurringBilling/CreateSubscriptionFromCustomerProfile.cs
+++ b/RecurringBilling/CreateSubscriptionFromCustomerProfile.cs
@@ -41,7 +41,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber      = "4111111111111111",
-                expirationDate  = "0718"
+                expirationDate  = "0719"
             };
 
             //standard api call to retrieve response

--- a/RecurringBilling/UpdateSubscription.cs
+++ b/RecurringBilling/UpdateSubscription.cs
@@ -32,7 +32,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0719"
+                expirationDate = "0728"
             };
 
             //standard api call to retrieve response

--- a/RecurringBilling/UpdateSubscription.cs
+++ b/RecurringBilling/UpdateSubscription.cs
@@ -32,7 +32,7 @@ namespace net.authorize.sample
             var creditCard = new creditCardType
             {
                 cardNumber = "4111111111111111",
-                expirationDate = "0718"
+                expirationDate = "0719"
             };
 
             //standard api call to retrieve response


### PR DESCRIPTION
Random generation of Account Number logic added as DebitBankAccount sample code starts failing if the same account number-routing number combination is used multiples times.